### PR TITLE
Create dynamic and responsive team display

### DIFF
--- a/components/Battle/BattleArena/BattleArena.module.scss
+++ b/components/Battle/BattleArena/BattleArena.module.scss
@@ -1,0 +1,30 @@
+@import "../../../styles/constants.scss";
+
+.arena {
+  margin-top: 1rem;
+  display: flex;
+
+  align-items: center;
+}
+
+.vs {
+  font-size: 1.5rem;
+  padding: 0.4rem 0.8rem;
+  background-color: $color-black-tint;
+  color: gray;
+  border-radius: 10px;
+}
+
+.playerNameIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 34.5em) {
+  .image {
+    width: 140px;
+    height: 140px;
+  }
+}

--- a/components/Battle/BattleArena/BattleArena.tsx
+++ b/components/Battle/BattleArena/BattleArena.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Image from "next/image";
+
+import { PokemonFighter } from "@/model/pokeFighter";
+
+import styles from "./BattleArena.module.scss";
+
+const BattleArena: React.FC<{
+  pokemon1: PokemonFighter;
+  pokemon2: PokemonFighter;
+}> = props => {
+  return (
+    <div className={styles.arena}>
+      <div>
+        <Image
+          alt={props.pokemon1.name}
+          src={props.pokemon1.sprites.front}
+          width={200}
+          height={200}
+          className={styles.image}
+        />
+        <div className={styles.playerNameIcon}>
+          <Image
+            alt="pokeball"
+            src={"/page-images/pokeball.png"}
+            width={20}
+            height={20}
+          />
+          <p>Player1</p>
+        </div>
+      </div>
+      <p className={styles.vs}>v/s</p>
+      <div>
+        <Image
+          alt={props.pokemon2.name}
+          src={props.pokemon2.sprites.front}
+          width={200}
+          height={200}
+          className={styles.image}
+        />
+        <div className={styles.playerNameIcon}>
+          <p>Player2</p>
+          <Image
+            alt="pokeball"
+            src={"/page-images/pokeball.png"}
+            width={20}
+            height={20}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BattleArena;

--- a/components/Battle/BattleTeamDisplay/BattleTeamDisplay.module.scss
+++ b/components/Battle/BattleTeamDisplay/BattleTeamDisplay.module.scss
@@ -1,0 +1,8 @@
+.displayContainer {
+  margin-top: 1.5rem;
+
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/components/Battle/BattleTeamDisplay/BattleTeamDisplay.tsx
+++ b/components/Battle/BattleTeamDisplay/BattleTeamDisplay.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { PokemonTeamDisplayStatus } from "@/model/pokeTeamDisplayStatus";
+
+import styles from "./BattleTeamDisplay.module.scss";
+import TeamDisplayStatus from "./TeamDisplayStatus/TeamDisplayStatus";
+
+const BattleTeamDisplay: React.FC<{
+  pokemonTeamsStatus: {
+    teamDisplay1: PokemonTeamDisplayStatus[];
+    teamDisplay2: PokemonTeamDisplayStatus[];
+  };
+}> = props => {
+  return (
+    <div className={styles.displayContainer}>
+      <TeamDisplayStatus teamStatus={props.pokemonTeamsStatus.teamDisplay1} />
+      <TeamDisplayStatus
+        teamStatus={props.pokemonTeamsStatus.teamDisplay2}
+        reversed
+      />
+    </div>
+  );
+};
+
+export default BattleTeamDisplay;

--- a/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.module.scss
+++ b/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.module.scss
@@ -1,0 +1,16 @@
+.teamDisplay {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.fainted {
+  filter: grayscale(100%);
+}
+
+@media (max-width: 34.5em) {
+  .image {
+    width: 20px;
+    height: 20px;
+  }
+}

--- a/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.tsx
+++ b/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Image from "next/image";
+
+import { PokemonTeamDisplayStatus } from "@/model/pokeTeamDisplayStatus";
+
+import styles from "./TeamDisplayStatus.module.scss";
+
+const TeamDisplayStatus: React.FC<{
+  teamStatus: PokemonTeamDisplayStatus[];
+  reversed?: boolean;
+}> = props => {
+  const mappedTeamDisplay = props.teamStatus.map((pokeDisplayState, index) => {
+    const isHidden = pokeDisplayState.status === "hidden";
+    const isFainted = pokeDisplayState.status === "fainted";
+
+    return (
+      <Image
+        key={`pokeStatus-${index}`}
+        alt={isHidden ? "pokeball" : "pokemon"}
+        src={
+          isHidden ? "/page-images/pokeball.png" : pokeDisplayState.spriteURL
+        }
+        width={25}
+        height={25}
+        className={`${styles.image} ${isFainted ? styles.fainted : ""}`}
+      />
+    );
+  });
+
+  if (props.reversed) {
+    mappedTeamDisplay.reverse();
+  }
+
+  return <div className={styles.teamDisplay}>{mappedTeamDisplay}</div>;
+};
+
+export default TeamDisplayStatus;

--- a/components/Pages/BattlePage/BattlePage.module.scss
+++ b/components/Pages/BattlePage/BattlePage.module.scss
@@ -11,38 +11,29 @@
 }
 
 .battleCard {
-  max-width: 30rem;
+  width: 100%;
+  max-width: 35rem;
   color: $color-white;
+
+  border: 1px solid $color-white;
+  border-radius: 15px;
+  padding: 1rem 2rem;
 
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.arena {
-  margin-top: 3rem;
-  display: flex;
-
-  align-items: center;
-
-  & p {
-    font-size: 1.5rem;
-    padding: 0.4rem 0.8rem;
-    background-color: $color-black-tint;
-    color: gray;
-    border-radius: 10px;
-  }
-}
-
 .battleStats {
-  width: 80%;
+  width: 100%;
+
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
 }
 
-.playerNameIcon {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+@media (max-width: 34.5em) {
+  .battleCard {
+    padding: 0.4rem 0.8rem;
+  }
 }

--- a/components/Pages/BattlePage/BattlePage.tsx
+++ b/components/Pages/BattlePage/BattlePage.tsx
@@ -1,7 +1,11 @@
-import React from "react";
-import Image from "next/image";
+import React, { useEffect, useState } from "react";
+// import Image from "next/image";
 
 import { PokemonFighter } from "@/model/pokeFighter";
+import { PokemonTeamDisplayStatus } from "@/model/pokeTeamDisplayStatus";
+
+import BattleTeamDisplay from "@/components/Battle/BattleTeamDisplay/BattleTeamDisplay";
+import BattleArena from "@/components/Battle/BattleArena/BattleArena";
 
 import styles from "./BattlePage.module.scss";
 
@@ -9,51 +13,26 @@ const BattlePage: React.FC<{
   player1team: PokemonFighter[];
   player2team: PokemonFighter[];
 }> = ({ player1team, player2team }) => {
+  const [player1CurrPokemon, setPlayer1CurrPokemon] = useState(0); //change 0 for random or user selected later
+  const [player2CurrPokemon, setPlayer2CurrPokemon] = useState(0); //change 0 for random or user selected later
+
+  const [teamDisplayStatus, setTeamDisplayStatus] = useState<{
+    teamDisplay1: PokemonTeamDisplayStatus[];
+    teamDisplay2: PokemonTeamDisplayStatus[];
+  }>({
+    teamDisplay1: getTeamDisplayStatus(player1team, player1CurrPokemon),
+    teamDisplay2: getTeamDisplayStatus(player2team, player2CurrPokemon)
+  });
+
   return (
     <div className={styles.battlePage}>
       <div className={styles.battleCard}>
         <h1 className={styles.title}>Battleground</h1>
-        <div className={styles.arena}>
-          <Image
-            alt="pikachu"
-            src={player1team[0].sprites.front}
-            width={200}
-            height={200}
-          />
-          <p>v/s</p>
-          <Image
-            alt="charizard"
-            src={player2team[1].sprites.front}
-            width={200}
-            height={200}
-          />
-        </div>
-        <div className={styles.battleStats}>
-          <div>
-            <div className={styles.playerNameIcon}>
-              <Image
-                alt="Profile user"
-                src={"/page-images/pokeball.png"}
-                width={20}
-                height={20}
-              />
-              <p>Player1</p>
-            </div>
-            <div />
-          </div>
-          <div>
-            <div className={styles.playerNameIcon}>
-              <p>Player2</p>
-              <Image
-                alt="Profile user"
-                src={"/page-images/pokeball.png"}
-                width={20}
-                height={20}
-              />
-            </div>
-            <div />
-          </div>
-        </div>
+        <BattleTeamDisplay pokemonTeamsStatus={teamDisplayStatus} />
+        <BattleArena
+          pokemon1={player1team[player1CurrPokemon]}
+          pokemon2={player2team[player2CurrPokemon]}
+        />
         <div className={styles.attacksContainer}>
           <div></div>
           <div></div>
@@ -66,3 +45,22 @@ const BattlePage: React.FC<{
 };
 
 export default BattlePage;
+
+function randomNumber(min: number, max: number) {
+  return Math.round(Math.random() * (max - min) + min);
+}
+
+function getTeamDisplayStatus(
+  playerTeamFighters: PokemonFighter[],
+  currentFighterIndex: number
+): PokemonTeamDisplayStatus[] {
+  return playerTeamFighters.map(pokeFighter => {
+    return {
+      spriteURL: pokeFighter.sprites.front,
+      status:
+        pokeFighter.id === playerTeamFighters[currentFighterIndex].id
+          ? "active"
+          : "hidden"
+    };
+  });
+}

--- a/model/pokeTeamDisplayStatus.ts
+++ b/model/pokeTeamDisplayStatus.ts
@@ -1,0 +1,4 @@
+export interface PokemonTeamDisplayStatus {
+  spriteURL: string;
+  status: "hidden" | "active" | "fainted";
+}


### PR DESCRIPTION
Implement a dynamic team display where you can see your remaining pokémons and your opponent's ones, this is controlled by an status so if we change the status to fainted the pokémon sprite will become gray. This team display works for any size (1-6) of pokémons that the players have selected.