### PR TITLE
create battling arena, add pokémon sprites styles, organize elements and add reactive health bars

### DIFF
--- a/components/Battle/BattleArena/BattleArena.module.scss
+++ b/components/Battle/BattleArena/BattleArena.module.scss
@@ -7,6 +7,13 @@
   align-items: center;
 }
 
+.arenaOverlay {
+  display: flex;
+  flex-direction: column;
+
+  align-items: center;
+}
+
 .vs {
   font-size: 1.5rem;
   padding: 0.4rem 0.8rem;
@@ -19,12 +26,29 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 @media (max-width: 34.5em) {
+  .vs {
+    font-size: 1.4rem;
+    padding: 0.3rem 0.6rem;
+  }
+
   .image {
     width: 140px;
     height: 140px;
+  }
+}
+
+@media (max-width: 21.5em) {
+  .image {
+    width: 80px;
+    height: 80px;
+  }
+
+  .vs {
+    font-size: 0.8rem;
+    padding: 0.1rem 0.2rem;
   }
 }

--- a/components/Battle/BattleArena/BattleArena.tsx
+++ b/components/Battle/BattleArena/BattleArena.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Image from "next/image";
 
 import { PokemonFighter } from "@/model/pokeFighter";
+import BattleHealthBar from "./BattleHealthBar/BattleHealthBar";
 
 import styles from "./BattleArena.module.scss";
 
@@ -11,7 +12,7 @@ const BattleArena: React.FC<{
 }> = props => {
   return (
     <div className={styles.arena}>
-      <div>
+      <div className={styles.arenaOverlay}>
         <Image
           alt={props.pokemon1.name}
           src={props.pokemon1.sprites.front}
@@ -19,6 +20,7 @@ const BattleArena: React.FC<{
           height={200}
           className={styles.image}
         />
+
         <div className={styles.playerNameIcon}>
           <Image
             alt="pokeball"
@@ -28,9 +30,13 @@ const BattleArena: React.FC<{
           />
           <p>Player1</p>
         </div>
+        <BattleHealthBar
+          maxHealthPoints={props.pokemon1.stats.hp}
+          currentHealthPoints={props.pokemon1.stats.hp}
+        />
       </div>
       <p className={styles.vs}>v/s</p>
-      <div>
+      <div className={styles.arenaOverlay}>
         <Image
           alt={props.pokemon2.name}
           src={props.pokemon2.sprites.front}
@@ -47,6 +53,10 @@ const BattleArena: React.FC<{
             height={20}
           />
         </div>
+        <BattleHealthBar
+          maxHealthPoints={props.pokemon2.stats.hp}
+          currentHealthPoints={props.pokemon2.stats.hp}
+        />
       </div>
     </div>
   );

--- a/components/Battle/BattleArena/BattleHealthBar/BattleHealthBar.module.scss
+++ b/components/Battle/BattleArena/BattleHealthBar/BattleHealthBar.module.scss
@@ -1,0 +1,12 @@
+.progress {
+  max-width: 9rem;
+  height: 2rem;
+
+  animation: progress 1s linear forwards;
+}
+
+@media (max-width: 21.5em) {
+  .progress {
+    max-width: 7rem;
+  }
+}

--- a/components/Battle/BattleArena/BattleHealthBar/BattleHealthBar.tsx
+++ b/components/Battle/BattleArena/BattleHealthBar/BattleHealthBar.tsx
@@ -1,0 +1,34 @@
+import styles from "./BattleHealthBar.module.scss";
+
+const color100 = "#00ff00";
+const color80 = "#80ff00";
+const color60 = "#ffff00";
+const color40 = "#ff8000";
+const color20 = "#ff0000";
+
+const BattleHealthBar: React.FC<{
+  maxHealthPoints: number;
+  currentHealthPoints: number;
+}> = ({ maxHealthPoints, currentHealthPoints }) => {
+  const healthPorcentage = (currentHealthPoints * 100) / maxHealthPoints;
+
+  let healthColor = color100;
+  if (healthPorcentage < 80) healthColor = color80;
+  if (healthPorcentage < 60) healthColor = color60;
+  if (healthPorcentage < 40) healthColor = color40;
+  if (healthPorcentage < 20) healthColor = color20;
+
+  return (
+    <div>
+      <progress
+        id="health"
+        value={currentHealthPoints}
+        max={maxHealthPoints}
+        style={{ accentColor: healthColor }}
+        className={styles.progress}
+      ></progress>
+    </div>
+  );
+};
+
+export default BattleHealthBar;

--- a/components/Battle/BattleMovesDisplay/BattleMovesDisplay.module.scss
+++ b/components/Battle/BattleMovesDisplay/BattleMovesDisplay.module.scss
@@ -1,0 +1,22 @@
+@import "../../../styles/constants.scss";
+
+.movesContainer {
+  margin-top: 3rem;
+  width: 100%;
+
+  border: 1px solid $color-white;
+  padding: 0.4rem 0.6rem;
+}
+
+.movesOverlay {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  gap: 0.5rem;
+}
+
+@media (max-width: 20.1em) {
+  .movesOverlay {
+    grid-template-columns: 1fr;
+  }
+}

--- a/components/Battle/BattleMovesDisplay/BattleMovesDisplay.tsx
+++ b/components/Battle/BattleMovesDisplay/BattleMovesDisplay.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { pokemonMove } from "@/model/pokeMove";
+
+import MoveItem from "./MoveItem/MoveItem";
+
+import styles from "./BattleMovesDisplay.module.scss";
+
+const BattleMovesDisplay: React.FC<{ pokemonMoves: pokemonMove[] }> = ({
+  pokemonMoves
+}) => {
+  return (
+    <div className={styles.movesContainer}>
+      <div className={styles.movesOverlay}>
+        {pokemonMoves.map(pokeMove => {
+          return <MoveItem key={pokeMove.id} pokemonMove={pokeMove} />;
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default BattleMovesDisplay;

--- a/components/Battle/BattleMovesDisplay/MoveItem/MoveItem.module.scss
+++ b/components/Battle/BattleMovesDisplay/MoveItem/MoveItem.module.scss
@@ -1,0 +1,26 @@
+.moveItem {
+  border-radius: 5px;
+
+  background-color: #f8f7f8;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+}
+
+.moveItem p {
+  font-size: 1.4rem;
+  font-weight: 500;
+  padding: 0.4rem 0.8rem;
+
+  color: black;
+}
+
+@media (max-width: 24em) {
+  .moveItem p {
+    font-size: 1.2rem;
+    padding: 0.2rem 0.4rem;
+  }
+}

--- a/components/Battle/BattleMovesDisplay/MoveItem/MoveItem.tsx
+++ b/components/Battle/BattleMovesDisplay/MoveItem/MoveItem.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { pokemonMove } from "@/model/pokeMove";
+
+import { getTypeColorByTypeName } from "@/helper/type-color";
+
+import styles from "./MoveItem.module.scss";
+
+const MoveItem: React.FC<{ pokemonMove: pokemonMove }> = ({ pokemonMove }) => {
+  return (
+    <div
+      className={styles.moveItem}
+      style={{
+        border: `6px solid ${getTypeColorByTypeName(pokemonMove.type)}`
+      }}
+    >
+      <p>{pokemonMove.name}</p>
+    </div>
+  );
+};
+
+export default MoveItem;

--- a/components/Battle/BattleTeamDisplay/BattleTeamDisplay.tsx
+++ b/components/Battle/BattleTeamDisplay/BattleTeamDisplay.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 import { PokemonTeamDisplayStatus } from "@/model/pokeTeamDisplayStatus";
+import TeamDisplayStatus from "./TeamDisplayStatus/TeamDisplayStatus";
 
 import styles from "./BattleTeamDisplay.module.scss";
-import TeamDisplayStatus from "./TeamDisplayStatus/TeamDisplayStatus";
 
 const BattleTeamDisplay: React.FC<{
   pokemonTeamsStatus: {

--- a/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.module.scss
+++ b/components/Battle/BattleTeamDisplay/TeamDisplayStatus/TeamDisplayStatus.module.scss
@@ -2,6 +2,8 @@
   display: flex;
   align-items: center;
   gap: 0.2rem;
+
+  flex-wrap: wrap;
 }
 
 .fainted {

--- a/components/Pages/BattlePage/BattlePage.module.scss
+++ b/components/Pages/BattlePage/BattlePage.module.scss
@@ -24,14 +24,6 @@
   align-items: center;
 }
 
-.battleStats {
-  width: 100%;
-
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-}
-
 @media (max-width: 34.5em) {
   .battleCard {
     padding: 0.4rem 0.8rem;

--- a/components/Pages/BattlePage/BattlePage.tsx
+++ b/components/Pages/BattlePage/BattlePage.tsx
@@ -6,6 +6,7 @@ import { PokemonTeamDisplayStatus } from "@/model/pokeTeamDisplayStatus";
 
 import BattleTeamDisplay from "@/components/Battle/BattleTeamDisplay/BattleTeamDisplay";
 import BattleArena from "@/components/Battle/BattleArena/BattleArena";
+import BattleMovesDisplay from "@/components/Battle/BattleMovesDisplay/BattleMovesDisplay";
 
 import styles from "./BattlePage.module.scss";
 
@@ -14,7 +15,7 @@ const BattlePage: React.FC<{
   player2team: PokemonFighter[];
 }> = ({ player1team, player2team }) => {
   const [player1CurrPokemon, setPlayer1CurrPokemon] = useState(0); //change 0 for random or user selected later
-  const [player2CurrPokemon, setPlayer2CurrPokemon] = useState(0); //change 0 for random or user selected later
+  const [player2CurrPokemon, setPlayer2CurrPokemon] = useState(2); //change 0 for random or user selected later
 
   const [teamDisplayStatus, setTeamDisplayStatus] = useState<{
     teamDisplay1: PokemonTeamDisplayStatus[];
@@ -33,22 +34,15 @@ const BattlePage: React.FC<{
           pokemon1={player1team[player1CurrPokemon]}
           pokemon2={player2team[player2CurrPokemon]}
         />
-        <div className={styles.attacksContainer}>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-        </div>
+        <BattleMovesDisplay
+          pokemonMoves={player1team[player1CurrPokemon].moves}
+        />
       </div>
     </div>
   );
 };
 
 export default BattlePage;
-
-function randomNumber(min: number, max: number) {
-  return Math.round(Math.random() * (max - min) + min);
-}
 
 function getTeamDisplayStatus(
   playerTeamFighters: PokemonFighter[],

--- a/helper/type-color.ts
+++ b/helper/type-color.ts
@@ -1,0 +1,24 @@
+const pokemonTypeColors = new Map<string, string>([
+  ["normal", "#A8A77A"],
+  ["fire", "#fc6c6d"],
+  ["water", "#76befe"],
+  ["electric", "#ffd76f"],
+  ["grass", "#49d0b0"],
+  ["ice", "#96D9D6"],
+  ["fighting", "#C22E28"],
+  ["poison", "#A33EA1"],
+  ["ground", "#E2BF65"],
+  ["flying", "#A98FF3"],
+  ["psychic", "#F95587"],
+  ["bug", "#A6B91A"],
+  ["rock", "#B6A136"],
+  ["ghost", "#735797"],
+  ["dragon", "#6F35FC"],
+  ["dark", "#705746"],
+  ["steel", "#B7B7CE"],
+  ["fairy", "#D685AD"]
+]);
+
+export function getTypeColorByTypeName(typeName: string) {
+  return pokemonTypeColors.get(typeName) || "";
+}


### PR DESCRIPTION
Create battling arena, add pokémon sprites styles and organize them with the new health bar elements, organize elements in a better way and create reactive health bars which change colors depending of the amount remaining.